### PR TITLE
#32: Define 'cwd' for non-RStudio environment

### DIFF
--- a/app.R
+++ b/app.R
@@ -6,6 +6,8 @@
 if (nzchar(Sys.getenv('RSTUDIO_USER_IDENTITY'))) {
   cwd = dirname(rstudioapi::getSourceEditorContext()$path)
   setwd(cwd)
+} else {
+  cwd = getwd()
 }
 
 ## utility functions


### PR DESCRIPTION
Resolves #32.